### PR TITLE
Made browser and runmode as a command line variables instead of properties variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ A Web Test Framework for developing regression suites. The test cases can be run
    -Ddataproviderthreadcount=3
 
 **NOTE**
-
-Run the above maven command (no testng.xml required) with the respective groups and thread counts.
-The screenshot listeners are configured in "pom.xml" under "< property >" tag.
+1. -Drunmode=remote or -Drunmode=local (default value is `local`)
+2. -Dbrowser=chrome or -Drunmode=firefox (default value is `chrome`)
+3. Run the above maven command (no testng.xml required) with the respective groups and thread counts.
+   The screenshot listeners are configured in "pom.xml" under "< property >" tag.
 
 # PROPERTIES SETUP FOR SELENIUM GRID
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <browser>chrome</browser>
+        <runmode>local</runmode>
     </properties>
 
     <dependencies>
@@ -45,11 +47,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>
@@ -100,6 +97,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
+                    <systemPropertyVariables>
+                        <browser>${browser}</browser>
+                        <runmode>${runmode}</runmode>
+                    </systemPropertyVariables>
                     <properties>
                         <property>
                             <name>listener</name>

--- a/src/main/java/io/saucelabs/portal/qa/commons/web/SauceLabsPortalConstants.java
+++ b/src/main/java/io/saucelabs/portal/qa/commons/web/SauceLabsPortalConstants.java
@@ -18,6 +18,10 @@ public final class SauceLabsPortalConstants {
     public static final String FAIL_PREFIX = "FAILED_";
     public static final String IMAGE_FORMAT = ".png";
 
+    public static final String RUN_MODE = "runmode";
+    public static final String BROWSER = "browser";
+    public static final String REMOTE = "remote";
+
     // DISCORD API
     public static final String DISCORD_WEBHOOK = ConfigLoader.getInstance().getDiscordUrl() + "/api/webhooks";
 }

--- a/src/main/java/io/saucelabs/portal/qa/drivermanager/WebDriverManager.java
+++ b/src/main/java/io/saucelabs/portal/qa/drivermanager/WebDriverManager.java
@@ -14,15 +14,15 @@ public class WebDriverManager implements DriverManager<WebDriver> {
 
     @Override
     public WebDriver getDriver() {
-        String runMode = ConfigLoader.getInstance().getRunMode();
+        String runMode = System.getProperty("runmode");
         String server = ConfigLoader.getInstance().getServerUrl();
-        String browserName = ConfigLoader.getInstance().getBrowser();
+        String browserName = System.getProperty("browser");
         WebDriverFactory webDriverFactory = new WebDriverFactory(browserName);
         if (runMode.equalsIgnoreCase("remote")) {
-            log.info("Executing the test cases in remote server {}", server);
+            log.info("Executing the test cases in run mode {} and browser {}", runMode, browserName);
             return webDriverFactory.createRemoteBrowserSession(server);
         } else {
-            log.info("Executing the test cases in local machine.");
+            log.info("Executing the test cases in local machine in the browser {}.", browserName);
             return webDriverFactory.createLocalBrowserSession();
         }
     }

--- a/src/main/java/io/saucelabs/portal/qa/drivermanager/WebDriverManager.java
+++ b/src/main/java/io/saucelabs/portal/qa/drivermanager/WebDriverManager.java
@@ -1,5 +1,6 @@
 package io.saucelabs.portal.qa.drivermanager;
 
+import io.saucelabs.portal.qa.commons.web.SauceLabsPortalConstants;
 import io.saucelabs.portal.qa.utils.ConfigLoader;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,17 +15,14 @@ public class WebDriverManager implements DriverManager<WebDriver> {
 
     @Override
     public WebDriver getDriver() {
-        String runMode = System.getProperty("runmode");
+        String runMode = System.getProperty(SauceLabsPortalConstants.RUN_MODE);
         String server = ConfigLoader.getInstance().getServerUrl();
-        String browserName = System.getProperty("browser");
+        String browserName = System.getProperty(SauceLabsPortalConstants.BROWSER);
         WebDriverFactory webDriverFactory = new WebDriverFactory(browserName);
-        if (runMode.equalsIgnoreCase("remote")) {
-            log.info("Executing the test cases in run mode {} and browser {}", runMode, browserName);
+        if (runMode.equalsIgnoreCase(SauceLabsPortalConstants.REMOTE))
             return webDriverFactory.createRemoteBrowserSession(server);
-        } else {
-            log.info("Executing the test cases in local machine in the browser {}.", browserName);
+        else
             return webDriverFactory.createLocalBrowserSession();
-        }
     }
 
     @Override

--- a/src/main/java/io/saucelabs/portal/qa/utils/ConfigLoader.java
+++ b/src/main/java/io/saucelabs/portal/qa/utils/ConfigLoader.java
@@ -49,23 +49,7 @@ public class ConfigLoader {
         else
             throw new SauceLabsPortalException("Sauce Labs Portal Password is null!");
     }
-
-    public String getRunMode() {
-        String runMode = PROPERTIES.getProperty("runmode");
-        if (runMode != null)
-            return runMode;
-        else
-            throw new SauceLabsPortalException("Run Mode is null!");
-    }
-
-    public String getBrowser() {
-        String browser = PROPERTIES.getProperty("browser");
-        if (browser != null)
-            return browser;
-        else
-            throw new SauceLabsPortalException("Browser is null!");
-    }
-
+    
     public String getServerUrl() {
         String serverUrl = PROPERTIES.getProperty("server");
         if (serverUrl != null)

--- a/src/main/java/resources/config.properties
+++ b/src/main/java/resources/config.properties
@@ -1,7 +1,5 @@
 saucelabs.url=https://www.saucedemo.com/
 username=standard_user
 password=secret_sauce
-runmode=local
-browser=chrome
 server=http://localhost:4444
 discord.url=https://discord.com


### PR DESCRIPTION
- Initially, run mode and browser values were read from the properties file. Now, we can send those values through the maven command line.
- Updated the usage in the README file.